### PR TITLE
fix: Address issues raised in code review 3266990

### DIFF
--- a/mystore-project-frontend/package.json
+++ b/mystore-project-frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --configuration production",
+    "start-prod": "ng serve --configuration production",
     "start-dev": "ng serve",
     "build": "ng build",
     "build-prod": "ng build --configuration production",


### PR DESCRIPTION
Added missing script:

`"start-prod": "ng serve --configuration production"`

to fix CircleCI Cypress run error:

```
npm ERR! missing script: start-prod
npm ERR! 
npm ERR! Did you mean one of these?
npm ERR!     start-dev
npm ERR!     start-e2e
npm ERR!     start-e2e-prod

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-10T08_10_40_827Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mystore-frontend@0.1.0 start-e2e-prod: `npm install && npm run build-prod && npm run start-prod`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the mystore-frontend@0.1.0 start-e2e-prod script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-10T08_10_40_851Z-debug.log


Exited with code exit status 1
CircleCI received exit code 1
```

